### PR TITLE
check instructor role when reviewing attempt before review date

### DIFF
--- a/numbas_lti/static/api.js
+++ b/numbas_lti/static/api.js
@@ -178,7 +178,7 @@ SCORM_API.prototype = {
 
         // Force review mode from now on if activity is completed - could be out of sync if resuming a session which wasn't saved properly.
         if(this.data['cmi.completion_status'] == 'completed') {
-            if(this.allow_review_from!==null && new Date()<this.allow_review_from) {
+            if(this.allow_review_from!==null && new Date()<this.allow_review_from && this.data['numbas.user_role'] != 'instructor') {
                 var player = document.getElementById('scorm-player');
                 player.parentElement.removeChild(player);
                 this.ajax_period = 0;


### PR DESCRIPTION
When attempting to review a student attempt from the dashboard when the "Allow students to review attempts from" was set, it would either lead to a broken URL or started a new attempt _for the instructor_. This small change now checks for the instructor role (or lack thereof) before redirecting or entering review mode.