### PR TITLE
Reopened attempts kept old end_time

### DIFF
--- a/numbas_lti/views/attempt.py
+++ b/numbas_lti/views/attempt.py
@@ -152,6 +152,7 @@ class ReopenAttemptView(MustBeInstructorMixin,generic.detail.DetailView):
     def get(self, request, *args, **kwargs):
         attempt = self.get_object()
         attempt.end_time = None
+        attempt.save()
         e = ScormElement.objects.create(
                 attempt=attempt,
                 key='cmi.completion_status',

--- a/numbas_lti/views/attempt.py
+++ b/numbas_lti/views/attempt.py
@@ -151,6 +151,7 @@ class ReopenAttemptView(MustBeInstructorMixin,generic.detail.DetailView):
 
     def get(self, request, *args, **kwargs):
         attempt = self.get_object()
+        attempt.end_time = None
         e = ScormElement.objects.create(
                 attempt=attempt,
                 key='cmi.completion_status',


### PR DESCRIPTION
When an attempt was reopened the end_time variable was not removed, leading to the incorrect final submission time in attempt summaries.

The changes below set the end_time to null when an attempt is reopened, allowing the finalise function in models.py to set the correct date/time when the attempt is resubmitted.