### PR TITLE
Add further trans, blocktrans tags and ugettext_lazy calls

### DIFF
--- a/numbas_lti/forms.py
+++ b/numbas_lti/forms.py
@@ -109,12 +109,12 @@ class CreateExamForm(ModelForm):
             try:
                 test_zipfile(zipfile.ZipFile(cleaned_data['package'].file))
             except ExamTestException as e:
-                raise forms.ValidationError("There was an error while testing this exam package: <pre>{}</pre>".format(utils.html.escape(e)))
+                raise forms.ValidationError(_("There was an error while testing this exam package:") + "<pre>{}</pre>".format(utils.html.escape(e)))
 
         return cleaned_data
 
 class ReplaceExamForm(CreateExamForm):
-    safe_replacement = forms.BooleanField(required=False,label='This is a safe replacement for the previous exam package')
+    safe_replacement = forms.BooleanField(required=False,label=_('This is a safe replacement for the previous exam package'))
 
 class RestoreExamForm(ModelForm):
     class Meta:
@@ -144,13 +144,13 @@ class CreateEditorLinkForm(ModelForm):
         try:
             response = requests.get('{}/api/handshake'.format(url), timeout=getattr(settings,'REQUEST_TIMEOUT',60))
             if response.status_code != 200:
-                raise Exception("Request returned HTTP status code {}.".format(response.status_code))
+                raise Exception(_("Request returned HTTP status code") + " {}.".format(response.status_code))
             data = response.json()
             if data.get('numbas_editor')!=1:
-                raise Exception("This doesn't seem to be a Numbas editor instance.")
+                raise Exception(_("This doesn't seem to be a Numbas editor instance."))
             self.cleaned_data['name'] = data['site_title']
         except (Exception,json.JSONDecodeError,requests.exceptions.RequestException) as e:
-            raise forms.ValidationError("There was an error connecting to this URL: {}".format(e))
+            raise forms.ValidationError(_("There was an error connecting to this URL:") + " {}".format(e))
         return url
 
     def save(self,commit=True):

--- a/numbas_lti/models.py
+++ b/numbas_lti/models.py
@@ -42,11 +42,11 @@ IDENTIFIER_FIELDS = [
 ]
 
 class LTIConsumer(models.Model):
-    url = models.URLField(blank=True,default='',verbose_name='Home URL of consumer')
+    url = models.URLField(blank=True,default='',verbose_name=_('Home URL of consumer'))
     key = models.CharField(max_length=100,unique=True,verbose_name=_('Consumer key'),help_text=_('The key should be human-readable, and uniquely identify this consumer.'))
     secret = models.CharField(max_length=100,verbose_name=_('Shared secret'))
     deleted = models.BooleanField(default=False)
-    identifier_field = models.CharField(default='', blank=True, max_length=20, choices=IDENTIFIER_FIELDS, verbose_name='Field used to identify students')
+    identifier_field = models.CharField(default='', blank=True, max_length=20, choices=IDENTIFIER_FIELDS, verbose_name=_('Field used to identify students'))
 
     objects = NotDeletedManager()
 
@@ -106,7 +106,7 @@ class ConsumerTimePeriod(models.Model):
 
 class ExtractPackage(models.Model):
     extract_folder = 'extracted_zips'
-    static_uuid = models.UUIDField(default=uuid.uuid4, editable=False, unique=True, verbose_name='UUID of exam package on disk')
+    static_uuid = models.UUIDField(default=uuid.uuid4, editable=False, unique=True, verbose_name=_('UUID of exam package on disk'))
 
     class Meta:
         abstract = True
@@ -122,9 +122,9 @@ class ExtractPackage(models.Model):
 # Create your models here.
 class Exam(ExtractPackage):
     title = models.CharField(max_length=300)
-    package = models.FileField(upload_to='exams/',verbose_name='Package file')
-    retrieve_url = models.URLField(blank=True,default='',verbose_name='URL used to retrieve the exam package')
-    rest_url = models.URLField(blank=True,default='',verbose_name='URL of the exam on the editor\'s REST API')
+    package = models.FileField(upload_to='exams/',verbose_name=_('Package file'))
+    retrieve_url = models.URLField(blank=True,default='',verbose_name=_('URL used to retrieve the exam package'))
+    rest_url = models.URLField(blank=True,default='',verbose_name=_('URL of the exam on the editor\'s REST API'))
     creation_time = models.DateTimeField(auto_now_add=True, verbose_name=_('Time this exam was created'))
     resource = models.ForeignKey('Resource',null=True,blank=True,on_delete=models.SET_NULL,related_name='exams')
 
@@ -209,7 +209,7 @@ class Resource(models.Model):
     report_mark_time = models.CharField(max_length=20,choices=REPORT_TIMES,default='immediately',verbose_name=_('When to report scores back'))
     email_receipts = models.BooleanField(default=False,verbose_name=_('Email attempt receipts to students on completion?'))
 
-    max_attempts = models.PositiveIntegerField(default=0,verbose_name=_('Maximum attempts per user'), help_text='Zero means unlimited attempts.')
+    max_attempts = models.PositiveIntegerField(default=0,verbose_name=_('Maximum attempts per user'), help_text=_('Zero means unlimited attempts.'))
 
     num_questions = models.PositiveIntegerField(default=0)
 
@@ -459,8 +459,8 @@ class Attempt(models.Model):
     completion_status_element = models.ForeignKey("ScormElement", on_delete=models.SET_NULL, related_name="current_completion_status_of", null=True)
     scaled_score = models.FloatField(default=0)
     scaled_score_element = models.ForeignKey("ScormElement", on_delete=models.SET_NULL, related_name="current_scaled_score_of", null=True)
-    sent_receipt = models.BooleanField(default=False,verbose_name='Has a completion receipt been sent?')
-    receipt_time = models.DateTimeField(blank=True,null=True,verbose_name='Time the completion receipt was sent')
+    sent_receipt = models.BooleanField(default=False,verbose_name=_('Has a completion receipt been sent?'))
+    receipt_time = models.DateTimeField(blank=True,null=True,verbose_name=_('Time the completion receipt was sent'))
 
     deleted = models.BooleanField(default=False)
     broken = models.BooleanField(default=False)
@@ -1007,7 +1007,7 @@ class ScormElement(models.Model):
     key = models.CharField(max_length=200)
     value = models.TextField()
     time = models.DateTimeField()
-    counter = models.IntegerField(default=0,verbose_name='Element counter to disambiguate elements with the same timestamp')
+    counter = models.IntegerField(default=0,verbose_name=_('Element counter to disambiguate elements with the same timestamp'))
     current = models.BooleanField(default=True) # is this the latest version?
 
     class Meta:
@@ -1091,10 +1091,10 @@ class RemarkedScormElement(models.Model):
     user = models.ForeignKey(User,on_delete=models.SET_NULL,null=True,related_name='remarked_elements')
 
 class EditorLink(models.Model):
-    name = models.CharField(max_length=200,verbose_name='Editor name')
-    url = models.URLField(verbose_name='Base URL of the editor',unique=True)
-    cached_available_exams = models.TextField(blank=True,editable=False,verbose_name='Cached JSON list of available exams from this editor')
-    last_cache_update = models.DateTimeField(blank=True,editable=False,verbose_name='Time of last cache update')
+    name = models.CharField(max_length=200,verbose_name=_('Editor name'))
+    url = models.URLField(verbose_name=_('Base URL of the editor'),unique=True)
+    cached_available_exams = models.TextField(blank=True,editable=False,verbose_name=_('Cached JSON list of available exams from this editor'))
+    last_cache_update = models.DateTimeField(blank=True,editable=False,verbose_name=_('Time of last cache update'))
 
     def __str__(self):
         return self.name
@@ -1132,12 +1132,12 @@ class EditorLink(models.Model):
             return []
 
 class EditorLinkProject(models.Model):
-    editor = models.ForeignKey(EditorLink,on_delete=models.CASCADE,related_name='projects',verbose_name='Editor that this project belongs to')
-    name = models.CharField(max_length=200,verbose_name='Name of the project')
-    description = models.TextField(blank=True,verbose_name='Description of the project')
-    remote_id = models.IntegerField(verbose_name='ID of the project on the editor')
-    homepage = models.URLField(verbose_name='URL of the project\'s homepage on the editor')
-    rest_url = models.URLField(verbose_name='URL of the project on the editor\'s REST API')
+    editor = models.ForeignKey(EditorLink,on_delete=models.CASCADE,related_name='projects',verbose_name=_('Editor that this project belongs to'))
+    name = models.CharField(max_length=200,verbose_name=_('Name of the project'))
+    description = models.TextField(blank=True,verbose_name=_('Description of the project'))
+    remote_id = models.IntegerField(verbose_name=_('ID of the project on the editor'))
+    homepage = models.URLField(verbose_name=_('URL of the project\'s homepage on the editor'))
+    rest_url = models.URLField(verbose_name=_('URL of the project on the editor\'s REST API'))
 
     class Meta:
         ordering = ['name']

--- a/numbas_lti/templates/numbas_lti/management/admin/consumer/list.html
+++ b/numbas_lti/templates/numbas_lti/management/admin/consumer/list.html
@@ -55,8 +55,8 @@
         <section>
             <h2>{% trans "Configuration information" %}</h2>
             <ul class="nav nav-tabs" role="tablist">
-                <li role="presentation" class="active"><a href="#config-xml" aria-controls="config-xml" role="tab" data-toggle="tab">Configuration by URL</a></li>
-                <li role="presentation"><a href="#config-manual" aria-controls="config-manual" role="tab" data-toggle="tab">Manual configuration</a></li>
+                <li role="presentation" class="active"><a href="#config-xml" aria-controls="config-xml" role="tab" data-toggle="tab">{% trans "Configuration by URL" %}</a></li>
+                <li role="presentation"><a href="#config-manual" aria-controls="config-manual" role="tab" data-toggle="tab">{% trans "Manual configuration" %}</a></li>
             </ul>
             <div class="tab-content">
                 <div role="tabpanel" class="tab-pane active" id="config-xml">

--- a/numbas_lti/templates/numbas_lti/management/admin/dashboard.html
+++ b/numbas_lti/templates/numbas_lti/management/admin/dashboard.html
@@ -19,7 +19,7 @@
 <h1>{% trans "Dashboard" %}</h1>
 
 <form method="GET" action="{% url 'global_search' %}">
-    <label for="search">Search for users, contexts or resources:</label>
+    <label for="search">{% trans "Search for users, contexts or resources:" %}</label>
     <input type="text" id="search" name="query" autocomplete="off">
     <button type="submit" class="btn btn-default">{% trans "Search" %}</button>
 </form>

--- a/numbas_lti/templates/numbas_lti/management/admin/editorlink/create.html
+++ b/numbas_lti/templates/numbas_lti/management/admin/editorlink/create.html
@@ -7,7 +7,7 @@
 {% block management_content %}
 <div class="container">
     <header>
-        <h1>Connect to a Numbas editor</h1>
+        <h1>{% trans "Connect to a Numbas editor" %}</h1>
     </header>
 
     <main>

--- a/numbas_lti/templates/numbas_lti/management/attempt_base.html
+++ b/numbas_lti/templates/numbas_lti/management/attempt_base.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block management_header %}
-    <p><a href="{% url 'manage_attempts' attempt.resource.pk %}">Back to attempts listing</a></p>
+<p><a href="{% url 'manage_attempts' attempt.resource.pk %}">{% trans "Back to attempts listing" %}</a></p>
 
     <h2>
         {% blocktrans with name=attempt.user.get_full_name %}Attempt by {{name}}{% endblocktrans %}

--- a/numbas_lti/templates/numbas_lti/management/attempts.html
+++ b/numbas_lti/templates/numbas_lti/management/attempts.html
@@ -107,7 +107,7 @@
                     <a class="btn btn-link" href="{% url 'delete_attempt' attempt.pk %}"><span class="text-danger"><span class="glyphicon glyphicon-remove"></span> {% trans "Delete" %}</span></a>
                 </td>
                 <td>
-                    {% if attempt.broken %}<span class="text-danger">{% trans "Broken" %}</span>{% else %}<span class="{% if attempt.completed %}text-success{% endif %}">{{attempt.completion_status}}</span> {% if attempt.completed %}<a class="btn btn-link" href="{% url 'reopen_attempt' attempt.pk %}">{% trans "(reopen)" %}</a>{% endif %}{% endif %}
+                    {% if attempt.broken %}<span class="text-danger">{% trans "Broken" %}</span>{% else %}<span class="{% if attempt.completed %}text-success{% endif %}">{{attempt.get_completion_status_display}}</span> {% if attempt.completed %}<a class="btn btn-link" href="{% url 'reopen_attempt' attempt.pk %}">{% trans "(reopen)" %}</a>{% endif %}{% endif %}
                 </td>
                 <td>
                     <div class="attempt-score">{{attempt.raw_score}} / {{attempt.max_score}} ({{attempt.scaled_score|percentage}}) {% if attempt.is_remarked %}{% trans "(remarked)" %}{% endif %}</div>

--- a/numbas_lti/templates/numbas_lti/management/resource_remark.html
+++ b/numbas_lti/templates/numbas_lti/management/resource_remark.html
@@ -29,9 +29,9 @@
         <input id="use-unsubmitted" type="checkbox" v-model="use_unsubmitted"> <label for="use-unsubmitted">{% trans "Use unsubmitted answers" %}
     </p>
     <p>
-        <button class="btn btn-primary" @click="remark_all"><span class="glyphicon glyphicon-repeat"></span> Remark all attempts</button>
-        <button class="btn btn-warning" @click="stop_marking"><span class="glyphicon glyphicon-stop"></span> Stop marking</button>
-        <button class="btn btn-danger" @click="save_changed_attempts" :disabled="changed_attempts.length==0 || saving"><span class="glyphicon glyphicon-save"></span> Save all changed attempts</button>
+        <button class="btn btn-primary" @click="remark_all"><span class="glyphicon glyphicon-repeat"></span> {% trans "Remark all attempts" %}</button>
+        <button class="btn btn-warning" @click="stop_marking"><span class="glyphicon glyphicon-stop"></span> {% trans "Stop marking" %}</button>
+        <button class="btn btn-danger" @click="save_changed_attempts" :disabled="changed_attempts.length==0 || saving"><span class="glyphicon glyphicon-save"></span> {% trans "Save all changed attempts" %}</button>
     </p>
 
     <div class="alert alert-default" v-if="remarking_all">
@@ -40,8 +40,8 @@
                 [[remarking_progress|percent]]%
           </div>
         </div>
-        <p>Time taken: <span v-if="remark_all_time">[[remark_all_time|duration]]</span></p>
-        <p>Estimated end: <span v-if="estimated_end">[[estimated_end|duration]]</span></p>
+        <p>{% trans "Time taken:" %} <span v-if="remark_all_time">[[remark_all_time|duration]]</span></p>
+        <p>{% trans "Estimated end:" %} <span v-if="estimated_end">[[estimated_end|duration]]</span></p>
     </div>
 
     <div class="alert alert-warning" v-if="save_error">
@@ -50,15 +50,15 @@
     </div>
 
     <p>
-        [[shown_attempts.length]] of [[num_attempts]] attempts shown.
+        [[shown_attempts.length]] {% trans "of" %} [[num_attempts]] {% trans "attempts shown." %}
         [[changed_attempts.length]] {% trans " changed attempts" %}.
         <label for="show-only">{% trans "Show:" %}</label> 
         <select id="show-only" v-model="show_only">
-            <option value="all">All attempts</option>
-            <option value="completed">Only completed attempts</option>
-            <option value="changed">Only changed scores</option>
-            <option value="increased">Only increased scores</option>
-            <option value="decreased">Only decreased scores</option>
+            <option value="all">{% trans "All attempts" %}</option>
+            <option value="completed">{% trans "Only completed attempts" %}</option>
+            <option value="changed">{% trans "Only changed scores" %}</option>
+            <option value="increased">{% trans "Only increased scores" %}</option>
+            <option value="decreased">{% trans "Only decreased scores" %}</option>
         </select>
     </p>
 
@@ -88,14 +88,14 @@
         <tbody>
             <tr class="hidden-attempts-count text-muted" v-if="num_attempts_hidden > 0">
                 <td colspan="6">
-                    [[num_attempts_hidden]] hidden [[ 'attempt' | pluralize(num_attempts_hidden) ]].
+                    {% trans "Number of hidden attempts:" %} [[num_attempts_hidden]].
                 </td>
             </tr>
             <template v-for="attempt in shown_attempts">
             <tr class="attempt" :class="{saved: attempt.status=='saved', 'error-saving': attempt.status=='error saving'}">
                 <td>[[attempt.user.full_name]]</td>
                 <td>[[attempt.user.identifier]]</td>
-                <td>[[attempt.completion_status]]</td>
+                <td>[[attempt.get_completion_status_display]]</td>
                 <td>[[attempt.original_raw_score|dp(3)]]/[[attempt.max_score|dp(3)]]</td>
                 <td>
                     <span v-if="attempt.status=='remarked' || attempt.status=='saved'">[[attempt.remarked_raw_score|dp(3)]]/[[attempt.max_score|dp(3)]]</span>

--- a/numbas_lti/templates/numbas_lti/management/resource_stats.html
+++ b/numbas_lti/templates/numbas_lti/management/resource_stats.html
@@ -52,19 +52,19 @@
     <div class="legend">
         <span class="num_not_attempted">
             <svg class="box" width="20" height="20"><rect width="20" height="20"></rect></svg>
-            Not attempted
+            {% trans "Not attempted" %}
         </span>
         <span class="num_incorrect">
             <svg class="box" width="20" height="20"><rect width="20" height="20"></rect></svg>
-            Incorrect
+            {% trans "Incorrect" %}
         </span>
         <span class="num_partial">
             <svg class="box" width="20" height="20"><rect width="20" height="20"></rect></svg>
-            Partially correct
+            {% trans "Partially correct" %}
         </span>
         <span class="num_correct">
             <svg class="box" width="20" height="20"><rect width="20" height="20"></rect></svg>
-            Correct
+            {% trans "Correct" %}
         </span>
     </div>
     <div class="chart">


### PR DESCRIPTION
This handles a few more strings that were untranslated.

I am not really familiar with the vue.js interaction, so in particular line 98 in numbas_lti/templates/numbas_lti/management/resource_remark.html should be double checked (but it works in my instance of the LTI provider, so I suppose it is OK).

There are a couple of things that I left out for the moment:

- I did not touch numbas_lti/templates/numbas_lti/management/admin/stress/view.html, since, if I understand correctly, there also is Javascript interacting with the terms (e.g. the pluralization) and I did not have time to figure out how the translation should be handled at this point.
- There are also some untranslated terms (and non-localized dates) in numbas_lti/static/resource-stats.js.
- The admin interface (i.e., translating the names of models).
- sr-only texts in templates (not sure what the best practice here is, but I suppose they actually should be translated?).
- The display of attempt data (numbas_lti/static/attempt_timeline.js).

The admin and sr-only terms I could do. For the javascript bits, I would probably need some pointer to how this should be done in order to get going.

In any case, the main point (which is done already, also without this PR - thanks again for that!) from my point of view is that the interface as it is seen by the students can be translated. Therefore this PR and the additional points I mentioned have fairly low priority.