### PR TITLE
correct the name of the variable

### DIFF
--- a/doc/source/installation/upgrade.rst
+++ b/doc/source/installation/upgrade.rst
@@ -14,7 +14,7 @@ v2.13
 
 There was an error in the base :file:`settings.py` file when localisation was introduced. 
 
-If you are using the English translation, in :file:`numbasltiprovider/settings.py`, change ``LOCALE = 'en-us'`` to ``LOCALE = 'en'``. 
+If you are using the English translation, in :file:`numbasltiprovider/settings.py`, change ``LOCALE_CODE = 'en-us'`` to ``LOCALE_CODE = 'en'``. 
 
 v2.11
 -----


### PR DESCRIPTION
First of all, I'm new to Django. But I think the correct variable name for the language should be `LOCALE_CODE` instead of `LOCALE`.

Please ignore this pull request if my understanding was incorrect. Thank you very much for this project!