### PR TITLE
correct the name of locale variable in upgrade doc

### DIFF
--- a/doc/source/installation/upgrade.rst
+++ b/doc/source/installation/upgrade.rst
@@ -14,7 +14,7 @@ v2.13
 
 There was an error in the base :file:`settings.py` file when localisation was introduced. 
 
-If you are using the English translation, in :file:`numbasltiprovider/settings.py`, change ``LOCALE = 'en-us'`` to ``LOCALE = 'en'``. 
+If you are using the English translation, in :file:`numbasltiprovider/settings.py`, change ``LANGUAGE_CODE = 'en-us'`` to ``LANGUAGE_CODE = 'en'``. 
 
 v2.11
 -----


### PR DESCRIPTION
I upgraded numbas-lti to v2.13.2 recently, and had to use the same locale variable name in `settings.py` as `LANGUAGE_CODE`. Setting the `LOCALE='en'` as suggested in the doc did not work.
Please accept this pull request if the correct variable is `LANGUAGE_CODE`, otherwise please feel free to close this pr so it will not confuse others. Thank you very much.