### PR TITLE
Fix adding Editor Link

### DIFF
--- a/numbas_lti/migrations/0071_nullable_last_cache_update.py
+++ b/numbas_lti/migrations/0071_nullable_last_cache_update.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('numbas_lti', '0070_auto_20211020_1236'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="editorlink",
+            name="last_cache_update",
+            field=models.DateTimeField(null=True)
+        ),
+    ]

--- a/numbas_lti/models.py
+++ b/numbas_lti/models.py
@@ -1324,7 +1324,7 @@ class EditorLink(models.Model):
     name = models.CharField(max_length=200,verbose_name=_('Editor name'))
     url = models.URLField(verbose_name=_('Base URL of the editor'),unique=True)
     cached_available_exams = models.TextField(blank=True,editable=False,verbose_name=_('Cached JSON list of available exams from this editor'))
-    last_cache_update = models.DateTimeField(blank=True,editable=False,verbose_name=_('Time of last cache update'))
+    last_cache_update = models.DateTimeField(null=True,blank=True,editable=False,verbose_name=_('Time of last cache update'))
 
     class Meta:
         verbose_name = _('editor link')


### PR DESCRIPTION
Adding an editor link currently fails with an internal server error.
In the logs I found a problem with the `last_cache_update` which was not nullable. A DataTimeField is saved as null when it is not set as opposed to a TextField that is set to an empty string. 