### PR TITLE
lti_entry links which specify the exam within an editorlink

### DIFF
--- a/numbas_lti/forms.py
+++ b/numbas_lti/forms.py
@@ -6,11 +6,10 @@ from django.forms import ModelForm, Form
 from django import forms, utils
 from django.utils.translation import gettext_lazy as _
 
+from .util import download_scorm_file
+
 from .models import Exam, Resource, DiscountPart, RemarkPart, LTIConsumer, EditorLink, EditorLinkProject, ConsumerTimePeriod, AccessChange, UsernameAccessChange, EmailAccessChange
 from .test_exam import test_zipfile, ExamTestException
-
-from django.core.files import File
-from io import BytesIO
 
 from django.contrib.auth.forms import UserCreationForm
 import bootstrap_datepicker_plus
@@ -185,12 +184,7 @@ class CreateExamForm(ModelForm):
         if package is None:
             if not retrieve_url:
                 raise forms.ValidationError(_("You must upload a file."))
-            scheme, netloc, path, params, qs, fragment = urlparse(retrieve_url)
-            query = parse_qs(qs)
-            query.setdefault('scorm','')
-            retrieve_url = urlunparse((scheme, netloc, path, params, urlencode(query,True), fragment))
-            package_bytes = requests.get(retrieve_url,timeout=getattr(settings,'REQUEST_TIMEOUT',60)).content
-            cleaned_data['package'] = File(BytesIO(package_bytes),name='exam.zip')
+            cleaned_data['package'] = download_scorm_file(retrieve_url) 
 
         if getattr(settings,'TEST_UPLOADED_EXAMS',False) and hasattr(settings,'NUMBAS_TESTING_FRAMEWORK_PATH'):
             try:

--- a/numbas_lti/models.py
+++ b/numbas_lti/models.py
@@ -513,6 +513,9 @@ class Resource(models.Model):
         from . import tasks
         tasks.resource_report_scores(self)
 
+    def get_settings_url(self):
+        return reverse('resource_settings',args=(self.pk,))
+
 
 class ReportProcess(models.Model):
     resource = models.ForeignKey(Resource,on_delete=models.CASCADE,related_name='report_processes')

--- a/numbas_lti/templates/numbas_lti/index.html
+++ b/numbas_lti/templates/numbas_lti/index.html
@@ -15,6 +15,8 @@
         </p>
         <p>{% trans "Here is this tool's Launch URL:" %}</p>
         <pre>{{entry_url}}</pre>
+        <p>{% trans "You can also specify that an exam from an editorlink should be used:" %}</p>
+        <pre>{{entry_url_with_editorlink_exam}}</pre>
 
         <p class="pull-right"><a href="{% url 'list_consumers' %}"><span class="glyphicon glyphicon-list"></span> {% trans "Administration (login required)" %}</a></p>
     </main>

--- a/numbas_lti/templates/numbas_lti/launch_errors/unknown_editorlink.html
+++ b/numbas_lti/templates/numbas_lti/launch_errors/unknown_editorlink.html
@@ -1,0 +1,14 @@
+{% extends "numbas_lti/base.html" %}
+{% load i18n %}
+
+{% block content %}
+<div class="container">
+    <header>
+        <h1>{% trans "Invalid editorlink reference" %}</h1>
+    </header>
+    <main>
+        <p>{% blocktrans %} The editorlink with ref {{editorlink_ref}} is not set up. {% endblocktrans %}</p>
+    </main>
+</div>
+{% endblock content %}
+

--- a/numbas_lti/templates/numbas_lti/launch_errors/unknown_exam_ref.html
+++ b/numbas_lti/templates/numbas_lti/launch_errors/unknown_exam_ref.html
@@ -1,0 +1,15 @@
+{% extends "numbas_lti/base.html" %}
+{% load i18n %}
+
+{% block content %}
+<div class="container">
+    <header>
+        <h1>{% trans "Exam ref not found" %}</h1>
+    </header>
+    <main>
+        <p>{% blocktrans %} The exam with ref {{exam_ref}} can't be found in the editorlink with ref {{editorlink_ref}}. {% endblocktrans %}</p>
+        <p>{% trans "Are you sure that the project to which this exam belongs, is selected by the LTI administrator?" %}</p>
+    </main>
+</div>
+{% endblock content %}
+

--- a/numbas_lti/urls.py
+++ b/numbas_lti/urls.py
@@ -5,6 +5,7 @@ from . import views
 urlpatterns = [
     path('', views.entry.index, name='index'),
     path('lti_entry', views.entry.lti_entry, name='lti_entry'),
+    path('lti_entry/<str:editorlink_ref>/<path:exam_ref>', views.entry.lti_entry_with_editorlink_exam, name='lti_entry_with_editorlink_exam'),
     path('check_cookie_entry', views.entry.check_cookie_entry, name='check_cookie_entry'),
     path('set_cookie_entry', views.entry.set_cookie_entry, name='set_cookie_entry'),
 

--- a/numbas_lti/views/entry.py
+++ b/numbas_lti/views/entry.py
@@ -1,4 +1,4 @@
-from .mixins import static_view, request_is_instructor, get_lti_entry_url, get_config_url
+from .mixins import static_view, request_is_instructor, get_lti_entry_url, get_lti_entry_url_with_editorlink_exam, get_config_url
 from numbas_lti.models import LTIConsumer, LTIUserData, LTILaunch
 from numbas_lti.models import Exam, EditorLink
 from django_auth_lti.patch_reverse import reverse
@@ -28,6 +28,7 @@ def index(request):
         return redirect(reverse('create_superuser'))
     context = {
         'entry_url': get_lti_entry_url(request),
+        'entry_url_with_editorlink_exam': get_lti_entry_url_with_editorlink_exam(request),
     }
     return render(request,'numbas_lti/index.html',context)
 

--- a/numbas_lti/views/mixins.py
+++ b/numbas_lti/views/mixins.py
@@ -16,6 +16,9 @@ INSTRUCTOR_ROLES = getattr(settings,'LTI_INSTRUCTOR_ROLES',['Instructor','Admini
 def get_lti_entry_url(request):
     return request.build_absolute_uri(reverse('lti_entry',exclude_resource_link_id=True))
 
+def get_lti_entry_url_with_editorlink_exam(request):
+        return request.build_absolute_uri(reverse('lti_entry_with_editorlink_exam', args= (":editorlink_ref", ":exam_ref"), exclude_resource_link_id=True))
+
 def get_config_url(request):
     return request.build_absolute_uri(reverse('config_xml',exclude_resource_link_id=True))
 

--- a/numbas_lti/views/resource.py
+++ b/numbas_lti/views/resource.py
@@ -51,10 +51,7 @@ class CreateExamView(HelpLinkMixin,ResourceManagementViewMixin,MustBeInstructorM
         exam.save()
         resource.exam = exam
         resource.save()
-        return http.HttpResponseRedirect(self.get_success_url())
-
-    def get_success_url(self):
-        return reverse('resource_settings',args=(self.request.resource.pk,))
+        return http.HttpResponseRedirect(resource.get_settings_url())
 
 class ReplaceExamView(CreateExamView):
     management_tab = 'settings'


### PR DESCRIPTION
# Context

Currently, the only way to create an LTI link is to use the `/lti_entry` path and then open it once as an instructor to set up the exam. This is enough if you see each course in the VLE as unrelated. We have, however, some courses that use Numbas LTI links and that are duplicated at the start of each academic year. When we copy the courses, the LTI links are copied as well, but they are entirely new LTI resources for the provider so we need to set up all exams again and this can be a lot of manual work.

The Numbas LTI provider does already support the use of editorlinks to link an Numbas editor to the Numbas LTI provider to easily select exams instead of needing to download the zip file manually and upload it manually.

# Proposed solution

This draft PR adds support for creating an lti link with the following path:
 - `/lti_entry/:editorlink_name/:exam_ref`
 - e.g. `/lti_entry/numbas/3017` where:
 	- The editorlink has name 'numbas' and point to the public editor
 	- 3017 is the id of the exam
 	- This would load https://numbas.mathcentre.ac.uk/exam/3017/trigonometry-and-vectors/

When this lti resource is opened and there is no exam associated with it, it will automatically download the zip file for the exam with reference `exam_ref` from the editor specified by `editorlink_name`.

When using this kind of lti link in courses, duplication of the courses works without any trouble.

# Questions and topics to discuss

This is a MVP version of what I think is useful. I create this draft PR to ask the following questions / discuss the following topics.

## Usefull feature?

Do you think that this feature is useful to merge into the main repo of the Numbas LTI provider?

## Refs

Instead of using the id of the editorlink and the id of the exam, I would like to use a (human readable) reference.

### Editor link ref

For the editorlink I currently use the name, but I think it would be better to add an extra char field named `ref` to an editorlink which can only contain alphanumerical characters.

### Exam reference

The exam ids are never actually stored in the database as an integer because they are only stored in the urls in the `cached_available_exams` json of the editorlink. The current implementation does not depend on the exam ids being integer. This implies that the current implementation would also work for api's returning an url like `https://numbas.mathcentre.ac.uk/api/exams/a-folder/an-exam-ref` (compared to `https://numbas.mathcentre.ac.uk/api/exams/3017/`).

For rumbas I would like to host exams by pretending to be a Numbas editor (by implementing the api calls) and I would use paths to files as their reference instead of an numeric id.


## Loading exams from projects that are not selected

Currently, the editorlink only keeps track of the exams of the projects that are selected by the admin (= the ones from which you can chose exams when using the normal `/lti_entry` path). The current implementation implies that you will only be able to load exams from projects that are selected by the admin.

I think that this is a valid solution.

## Code style

I would like to get some general feedback on the code style that I used and on the structure of the code. I was, for example, not sure where to put the `download_scorm_file` function that I extracted.