### PR TITLE
Fix standalone scripts when automatic remarking

### DIFF
--- a/numbas_lti/static/resource_remark_iframe.js
+++ b/numbas_lti/static/resource_remark_iframe.js
@@ -3,8 +3,14 @@ function die(e) {
     alert(interpolate(gettext("There's been an error: %s"),[e.message]));
 }
 
+const exam_data_json = document.getElementById('exam-data-json').textContent;
+const exam_data = JSON.parse(exam_data_json);
+
 const numbas_ready = new Promise((resolve,reject) => {
     try {
+        Numbas.getStandaloneFileURL = function(extension, path) {
+		return exam_data['extracted_url']+'/extensions/'+extension+'/standalone_scripts/'+path;
+        }
         Numbas.queueScript('web-remarking',['start-exam'],function() {
             try {
                 for(var x in Numbas.extensions) {

--- a/numbas_lti/templates/numbas_lti/management/resource_remark_iframe.html
+++ b/numbas_lti/templates/numbas_lti/management/resource_remark_iframe.html
@@ -8,6 +8,7 @@
         {% get_current_language as LANGUAGE_CODE %}
         <script src="{% statici18n LANGUAGE_CODE %}"></script>
         <script src="{{scripts_url}}"></script>
+        {{exam_data|json_script:"exam-data-json" }}
         <script src="{% static 'resource_remark_iframe.js' %}"></script>
     </head>
 </html>

--- a/numbas_lti/views/resource.py
+++ b/numbas_lti/views/resource.py
@@ -582,6 +582,9 @@ class RemarkIframeView(MustHaveExamMixin,ResourceManagementViewMixin,MustBeInstr
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args,**kwargs)
         resource = self.object
+        context['exam_data'] = {
+            'extracted_url': resource.exam.extracted_url,
+        }
         context['scripts_url'] = resource.exam.extracted_url +'/scripts.js'
         return context
 


### PR DESCRIPTION
Standalone scripts are loaded relative to the exam's extracted_url.

When remarking, execute pre-submit promises sequentially rather than
in parallel. The pre-submit cache is now also cleared.